### PR TITLE
Add a few things and make lots of things translatable

### DIFF
--- a/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
+++ b/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
@@ -66,7 +66,7 @@ public class CMD_PlayMusic implements CommandExecutor {
         + ChatColor.GREEN + "Config Reload!");
     }
     sender.sendMessage(ChatColor.GRAY + "/jm " + ChatColor.GREEN + "stop  " + ChatColor.DARK_GRAY + "| "
-        + ChatColor.GREEN + "Stop Song Playing!");
+        + ChatColor.GREEN + plugin.getConfig().getString("messages.help.stop"));
     sender.sendMessage(ChatColor.GRAY + "======= " + ChatColor.GREEN + plugin.prefix + ChatColor.GRAY + "=======");
   }
 

--- a/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
+++ b/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
@@ -61,8 +61,10 @@ public class CMD_PlayMusic implements CommandExecutor {
 
   private void sendInstructions(CommandSender sender) {
     sender.sendMessage(ChatColor.GRAY + "======= " + ChatColor.GREEN + plugin.prefix + ChatColor.GRAY + "=======");
+    if(sender.hasPermission("JoinMusic.command.reload")) {
     sender.sendMessage(ChatColor.GRAY + "/jm " + ChatColor.GREEN + "reload  " + ChatColor.DARK_GRAY + "| "
         + ChatColor.GREEN + "Config Reload!");
+    }
     sender.sendMessage(ChatColor.GRAY + "/jm " + ChatColor.GREEN + "stop  " + ChatColor.DARK_GRAY + "| "
         + ChatColor.GREEN + "Stop Song Playing!");
     sender.sendMessage(ChatColor.GRAY + "======= " + ChatColor.GREEN + plugin.prefix + ChatColor.GRAY + "=======");

--- a/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
+++ b/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
@@ -106,13 +106,13 @@ public class CMD_PlayMusic implements CommandExecutor {
         if (commandSender.hasPermission("JoinMusic.command.stop")) {
           list.add("stop");
         }
-        /* Disabled since can't check if the setting is active because this is static and Main isn't
            if (commandSender.hasPermission("JoinMusic.command.disableOwn")) {
+        	list.add("enable");
             list.add("disable");
           }
-        */
         if (!commandSender.hasPermission("JoinMusic.command.stop")
-            && !commandSender.hasPermission("JoinMusic.command.reload")) {
+            && !commandSender.hasPermission("JoinMusic.command.reload")
+            && !commandSender.hasPermission("JoinMusic.command.disableOwn")) {
           list.add(" ");
         }
         return list;

--- a/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
+++ b/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
@@ -101,11 +101,13 @@ public class CMD_PlayMusic implements CommandExecutor {
     }
     sender.sendMessage(ChatColor.GRAY + "/jm " + ChatColor.GREEN + "stop  " + ChatColor.DARK_GRAY + "| "
         + ChatColor.GREEN + plugin.getConfig().getString("messages.help.stop"));
-    sender.sendMessage(ChatColor.GRAY + "/jm " + ChatColor.GREEN + "disable  " + ChatColor.DARK_GRAY + "| "
-        + ChatColor.GREEN + plugin.getConfig().getString("messages.help.disableOwn"));
-    sender.sendMessage(ChatColor.GRAY + "/jm " + ChatColor.GREEN + "enable   " + ChatColor.DARK_GRAY + "| "
-            + ChatColor.GREEN + plugin.getConfig().getString("messages.help.enableOwn"));
-    sender.sendMessage(ChatColor.GRAY + "======= " + ChatColor.GREEN + plugin.prefix + ChatColor.GRAY + "=======");
+    if(sender.hasPermission("JoinMusic.command.disableOwn")) {
+      sender.sendMessage(ChatColor.GRAY + "/jm " + ChatColor.GREEN + "disable  " + ChatColor.DARK_GRAY + "| "
+          + ChatColor.GREEN + plugin.getConfig().getString("messages.help.disableOwn"));
+      sender.sendMessage(ChatColor.GRAY + "/jm " + ChatColor.GREEN + "enable   " + ChatColor.DARK_GRAY + "| "
+          + ChatColor.GREEN + plugin.getConfig().getString("messages.help.enableOwn"));
+      sender.sendMessage(ChatColor.GRAY + "======= " + ChatColor.GREEN + plugin.prefix + ChatColor.GRAY + "=======");
+    }
   }
 
   public static TabCompleter tabCompleter = new TabCompleter() {

--- a/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
+++ b/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
@@ -74,7 +74,20 @@ public class CMD_PlayMusic implements CommandExecutor {
           sendInstructions(player);
         }
       } else {
-        sender.sendMessage(plugin.prefix + "This command is not for console!");
+    	  if(args.length == 1 && args[0].equalsIgnoreCase("reload")) {
+    		  plugin.reloadConfig();
+              plugin.loadUserConfigsIfNeeded();
+              try {
+                plugin.reloadConfig();
+                plugin.loadUserConfigsIfNeeded();
+                sender
+                  .sendMessage(plugin.cprefix + plugin.getConfig().getString("messages.reload"));
+                } catch (Exception exception) {
+                  sender.sendMessage(plugin.cprefix + ChatColor.RED + "Reload failed!");
+                }
+    	  }else {
+    		  sender.sendMessage(plugin.cprefix + "Only reload is for console!");
+    	  }
       }
     }
     return true;

--- a/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
+++ b/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
@@ -30,8 +30,7 @@ public class CMD_PlayMusic implements CommandExecutor {
           if (args[0].equalsIgnoreCase("reload")) {
             if (sender.hasPermission("JoinMusic.command.reload")) {
               try {
-                plugin.reloadConfig();
-                plugin.loadUserConfigsIfNeeded();
+                plugin.reloadConfigs();
                 player
                     .sendMessage(plugin.prefix + ChatColor.DARK_AQUA + plugin.getConfig().getString("messages.reload"));
               } catch (Exception exception) {
@@ -75,11 +74,8 @@ public class CMD_PlayMusic implements CommandExecutor {
         }
       } else {
     	  if(args.length == 1 && args[0].equalsIgnoreCase("reload")) {
-    		  plugin.reloadConfig();
-              plugin.loadUserConfigsIfNeeded();
               try {
-                plugin.reloadConfig();
-                plugin.loadUserConfigsIfNeeded();
+                plugin.reloadConfigs();
                 sender
                   .sendMessage(plugin.cprefix + plugin.getConfig().getString("messages.reload"));
                 } catch (Exception exception) {

--- a/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
+++ b/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
@@ -56,12 +56,8 @@ public class CMD_PlayMusic implements CommandExecutor {
         	  }
           }else if (args[0].equalsIgnoreCase("enable") && plugin.getConfig().getBoolean("options.allowDisabling")) {
         	  if(sender.hasPermission("JoinMusic.command.disableOwn")) {
-        		// Preventing to set it to enabled if it doesn't exist, saving file size
-        		// It's not possible to just remove it with FileConfiguration I think
-        		if(plugin.getUserConfigs().isSet(player.getUniqueId().toString())) {
-        		  plugin.getUserConfigs().set(player.getUniqueId().toString(),false);
+        		  plugin.getUserConfigs().set(player.getUniqueId().toString(),null);
         		  plugin.saveUserConfigs();
-        		}
         		sender.sendMessage(plugin.prefix + plugin.getConfig().getString("messages.enabled").replaceAll("&", "§"));
         	  } else {
         		sender.sendMessage(plugin.prefix + noperm);

--- a/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
+++ b/src/main/java/de/t0biii/music/commands/CMD_PlayMusic.java
@@ -30,7 +30,7 @@ public class CMD_PlayMusic implements CommandExecutor {
           if (args[0].equalsIgnoreCase("reload")) {
             if (sender.hasPermission("JoinMusic.command.reload")) {
               try {
-                plugin.reloadConfigs();
+                plugin.cm.reloadConfigs();
                 player
                     .sendMessage(plugin.prefix + ChatColor.DARK_AQUA + plugin.getConfig().getString("messages.reload"));
               } catch (Exception exception) {
@@ -48,16 +48,16 @@ public class CMD_PlayMusic implements CommandExecutor {
             }
           } else if (args[0].equalsIgnoreCase("disable") && plugin.getConfig().getBoolean("options.allowDisabling")) {
         	  if(sender.hasPermission("JoinMusic.command.disableOwn")) {
-        		plugin.getUserConfigs().set(player.getUniqueId().toString(),true);
+        		plugin.cm.getUserConfigs().set(player.getUniqueId().toString(),true);
         		sender.sendMessage(plugin.prefix + plugin.getConfig().getString("messages.disabled").replaceAll("&", "§"));
-       		    plugin.saveUserConfigs();
+       		    plugin.cm.saveUserConfigs();
         	  }else {
         		sender.sendMessage(plugin.prefix + noperm);
         	  }
           }else if (args[0].equalsIgnoreCase("enable") && plugin.getConfig().getBoolean("options.allowDisabling")) {
         	  if(sender.hasPermission("JoinMusic.command.disableOwn")) {
-        		  plugin.getUserConfigs().set(player.getUniqueId().toString(),null);
-        		  plugin.saveUserConfigs();
+        		  plugin.cm.getUserConfigs().set(player.getUniqueId().toString(),null);
+        		  plugin.cm.saveUserConfigs();
         		sender.sendMessage(plugin.prefix + plugin.getConfig().getString("messages.enabled").replaceAll("&", "§"));
         	  } else {
         		sender.sendMessage(plugin.prefix + noperm);
@@ -71,7 +71,7 @@ public class CMD_PlayMusic implements CommandExecutor {
       } else {
     	  if(args.length == 1 && args[0].equalsIgnoreCase("reload")) {
               try {
-                plugin.reloadConfigs();
+                plugin.cm.reloadConfigs();
                 sender
                   .sendMessage(plugin.cprefix + plugin.getConfig().getString("messages.reload"));
                 } catch (Exception exception) {

--- a/src/main/java/de/t0biii/music/domain/ConfigManager.java
+++ b/src/main/java/de/t0biii/music/domain/ConfigManager.java
@@ -23,6 +23,7 @@ public class ConfigManager {
     this.plugin.getConfig().addDefault("messages.reload", "The reload was successful!");
     this.plugin.getConfig().addDefault("messages.stop", "The song was stopped!");
     this.plugin.getConfig().addDefault("messages.no-permission", "You don't have enough permissions");
+    this.plugin.getConfig().addDefault("messages.playing", "&2Started Playing the Song: &a&l%song%");
     this.plugin.getConfig().addDefault("options.metrics", true);
 
     this.plugin.getConfig().options().copyDefaults(true);

--- a/src/main/java/de/t0biii/music/domain/ConfigManager.java
+++ b/src/main/java/de/t0biii/music/domain/ConfigManager.java
@@ -22,6 +22,7 @@ public class ConfigManager {
     this.plugin.getConfig().addDefault("messages.reload", "The reload was successful!");
     this.plugin.getConfig().addDefault("messages.stop", "The song was stopped!");
     this.plugin.getConfig().addDefault("messages.no-permission", "You don't have enough permissions");
+    this.plugin.getConfig().addDefault("messages.help.stop", "Stop Song Playing!");
     this.plugin.getConfig().addDefault("messages.playing", "&2Started Playing the Song: &a&l%song%");
     this.plugin.getConfig().addDefault("options.metrics", true);
 

--- a/src/main/java/de/t0biii/music/domain/ConfigManager.java
+++ b/src/main/java/de/t0biii/music/domain/ConfigManager.java
@@ -21,7 +21,7 @@ public class ConfigManager {
     this.plugin.getConfig().addDefault("options.delaySong", 2);
     this.plugin.getConfig().addDefault("options.allowDisabling", true);
     this.plugin.getConfig().addDefault("messages.reload", "The reload was successful!");
-    this.plugin.getConfig().addDefault("messages.stop", "&3Stopped playing the song! &7&oYou can disable playing a song on join with &b&o/jm stop");
+    this.plugin.getConfig().addDefault("messages.stop", "&3Stopped playing the song! &7&oYou can disable playing a song on join with &b&o/jm disable");
     this.plugin.getConfig().addDefault("messages.no-permission", "&cYou don't have enough permissions");
     this.plugin.getConfig().addDefault("messages.help.stop", "Stop playing the Song!");
     this.plugin.getConfig().addDefault("messages.help.disableOwn", "Disable playing a song when joining");

--- a/src/main/java/de/t0biii/music/domain/ConfigManager.java
+++ b/src/main/java/de/t0biii/music/domain/ConfigManager.java
@@ -18,7 +18,6 @@ public class ConfigManager {
     this.plugin.getConfig().addDefault("options.music.Mode", "MonoMode");
     this.plugin.getConfig().addDefault("options.update-check", true);
     this.plugin.getConfig().addDefault("options.updateinfo", true);
-    this.plugin.getConfig().addDefault("options.printSongTitel", true);
     this.plugin.getConfig().addDefault("options.delaySong", 2);
     this.plugin.getConfig().addDefault("messages.reload", "The reload was successful!");
     this.plugin.getConfig().addDefault("messages.stop", "The song was stopped!");

--- a/src/main/java/de/t0biii/music/domain/ConfigManager.java
+++ b/src/main/java/de/t0biii/music/domain/ConfigManager.java
@@ -20,7 +20,7 @@ public class ConfigManager {
   }
 
   public void loadConfig() {
-    this.plugin.getConfig().options().header("Plugin by itzTobi_!\nChange at your own risk\nOnly the messages with color codes here support color codes. The rest have a default color");
+    this.plugin.getConfig().options().header("Plugin by itzTobi_!\nChange at your own risk\nOnly the messages with color codes here support color codes. The rest have a default color\nTo disable the Playing song message, empty it (set it to '')");
     this.plugin.getConfig().addDefault("music", "Song.nbs");
     this.plugin.getConfig().addDefault("options.music.random", false);
     this.plugin.getConfig().addDefault("options.music.RandomFoldername", "random");

--- a/src/main/java/de/t0biii/music/domain/ConfigManager.java
+++ b/src/main/java/de/t0biii/music/domain/ConfigManager.java
@@ -19,16 +19,16 @@ public class ConfigManager {
     this.plugin.getConfig().addDefault("options.update-check", true);
     this.plugin.getConfig().addDefault("options.updateinfo", true);
     this.plugin.getConfig().addDefault("options.delaySong", 2);
-    this.plugin.getConfig().addDefault("options.allowDisabling", false);
+    this.plugin.getConfig().addDefault("options.allowDisabling", true);
     this.plugin.getConfig().addDefault("messages.reload", "The reload was successful!");
-    this.plugin.getConfig().addDefault("messages.stop", "&3The song was stopped!");
+    this.plugin.getConfig().addDefault("messages.stop", "&3Stopped playing the song! &7&oYou can disable playing a song on join with &b&o/jm stop");
     this.plugin.getConfig().addDefault("messages.no-permission", "&cYou don't have enough permissions");
     this.plugin.getConfig().addDefault("messages.help.stop", "Stop playing the Song!");
     this.plugin.getConfig().addDefault("messages.help.disableOwn", "Disable playing a song when joining");
     this.plugin.getConfig().addDefault("messages.help.enableOwn", "Enable playing a song when joining");
-    this.plugin.getConfig().addDefault("messages.disabled","&3Disabled playing a song on join");
-    this.plugin.getConfig().addDefault("messages.enabled","&3Enabled playing a song on join");
-    this.plugin.getConfig().addDefault("messages.playing", "&2Started Playing the Song: &a&l%song%");
+    this.plugin.getConfig().addDefault("messages.disabled","&3Disabled playing a song when joining. To enable it again, use &b/jm enable");
+    this.plugin.getConfig().addDefault("messages.enabled","&3Enabled playing a song when joining");
+    this.plugin.getConfig().addDefault("messages.playing", "&2Started Playing the Song: &a&l%song%.&2 You can stop it using &a/jm stop");
     this.plugin.getConfig().addDefault("options.metrics", true);
 
     this.plugin.getConfig().options().copyDefaults(true);

--- a/src/main/java/de/t0biii/music/domain/ConfigManager.java
+++ b/src/main/java/de/t0biii/music/domain/ConfigManager.java
@@ -11,7 +11,7 @@ public class ConfigManager {
   }
 
   public void loadConfig() {
-    this.plugin.getConfig().options().header("Plugin by itzTobi_!\nChange at your own risk");
+    this.plugin.getConfig().options().header("Plugin by itzTobi_!\nChange at your own risk\nOnly the messages with color codes here support color codes. The rest have a default color");
     this.plugin.getConfig().addDefault("music", "Song.nbs");
     this.plugin.getConfig().addDefault("options.music.random", false);
     this.plugin.getConfig().addDefault("options.music.RandomFoldername", "random");
@@ -19,10 +19,15 @@ public class ConfigManager {
     this.plugin.getConfig().addDefault("options.update-check", true);
     this.plugin.getConfig().addDefault("options.updateinfo", true);
     this.plugin.getConfig().addDefault("options.delaySong", 2);
+    this.plugin.getConfig().addDefault("options.allowDisabling", false);
     this.plugin.getConfig().addDefault("messages.reload", "The reload was successful!");
-    this.plugin.getConfig().addDefault("messages.stop", "The song was stopped!");
-    this.plugin.getConfig().addDefault("messages.no-permission", "You don't have enough permissions");
-    this.plugin.getConfig().addDefault("messages.help.stop", "Stop Song Playing!");
+    this.plugin.getConfig().addDefault("messages.stop", "&3The song was stopped!");
+    this.plugin.getConfig().addDefault("messages.no-permission", "&cYou don't have enough permissions");
+    this.plugin.getConfig().addDefault("messages.help.stop", "Stop playing the Song!");
+    this.plugin.getConfig().addDefault("messages.help.disableOwn", "Disable playing a song when joining");
+    this.plugin.getConfig().addDefault("messages.help.enableOwn", "Enable playing a song when joining");
+    this.plugin.getConfig().addDefault("messages.disabled","&3Disabled playing a song on join");
+    this.plugin.getConfig().addDefault("messages.enabled","&3Enabled playing a song on join");
     this.plugin.getConfig().addDefault("messages.playing", "&2Started Playing the Song: &a&l%song%");
     this.plugin.getConfig().addDefault("options.metrics", true);
 

--- a/src/main/java/de/t0biii/music/domain/ConfigManager.java
+++ b/src/main/java/de/t0biii/music/domain/ConfigManager.java
@@ -28,7 +28,7 @@ public class ConfigManager {
     this.plugin.getConfig().addDefault("messages.help.enableOwn", "Enable playing a song when joining");
     this.plugin.getConfig().addDefault("messages.disabled","&3Disabled playing a song when joining. To enable it again, use &b/jm enable");
     this.plugin.getConfig().addDefault("messages.enabled","&3Enabled playing a song when joining");
-    this.plugin.getConfig().addDefault("messages.playing", "&2Started Playing the Song: &a&l%song%.&2 You can stop it using &a/jm stop");
+    this.plugin.getConfig().addDefault("messages.playing", "&2Started Playing the Song: &a&l%song%&2. You can stop it using &a/jm stop");
     this.plugin.getConfig().addDefault("options.metrics", true);
 
     this.plugin.getConfig().options().copyDefaults(true);

--- a/src/main/java/de/t0biii/music/domain/ConfigManager.java
+++ b/src/main/java/de/t0biii/music/domain/ConfigManager.java
@@ -1,10 +1,19 @@
 package de.t0biii.music.domain;
 
+import java.io.File;
+import java.io.IOException;
+
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
 import de.t0biii.music.main.Main;
 
 public class ConfigManager {
 
   private Main plugin;
+  
+  private FileConfiguration userConfigs = null;
 
   public ConfigManager(Main plugin) {
     this.plugin = plugin;
@@ -32,5 +41,44 @@ public class ConfigManager {
     this.plugin.getConfig().addDefault("options.metrics", true);
 
     this.plugin.getConfig().options().copyDefaults(true);
+  }
+
+  public void reloadConfigs() {
+	  plugin.reloadConfig();
+	  loadConfig();
+	  plugin.saveConfig();
+	  loadUserConfigsIfNeeded();
+  }
+  
+  private void createUserConfigs() {
+	  File userConfigsFile = new File(plugin.getDataFolder(), "disabledPlayers.yml");
+    if (!userConfigsFile.exists()) {
+      userConfigsFile.getParentFile().mkdirs();
+      plugin.saveResource("disabledPlayers.yml", false);
+    }
+	  this.userConfigs = new YamlConfiguration();
+      try {
+        this.userConfigs.load(userConfigsFile);
+    } catch (IOException | InvalidConfigurationException e) {
+        e.printStackTrace();
+    }
+  }
+  
+  public FileConfiguration getUserConfigs() {
+	return this.userConfigs;
+  }
+  
+  public void loadUserConfigsIfNeeded() {
+	if (plugin.getConfig().getBoolean("options.allowDisabling")) {
+	  createUserConfigs();
+	}
+  }
+  
+  public void saveUserConfigs() {
+	try {
+	  this.userConfigs.save(new File(plugin.getDataFolder(), "disabledPlayers.yml"));
+	} catch (IOException e) {
+		e.printStackTrace();
+	}
   }
 }

--- a/src/main/java/de/t0biii/music/domain/Music.java
+++ b/src/main/java/de/t0biii/music/domain/Music.java
@@ -23,7 +23,7 @@ public class Music {
 
   public static void start(Player player, Main plugin){
 	if(plugin.getConfig().getBoolean("options.allowDisabling")) {
-		if(plugin.getUserConfigs().getBoolean(player.getUniqueId().toString(),false)) {
+		if(plugin.cm.getUserConfigs().getBoolean(player.getUniqueId().toString(),false)) {
 			return;
 		}
 	}

--- a/src/main/java/de/t0biii/music/domain/Music.java
+++ b/src/main/java/de/t0biii/music/domain/Music.java
@@ -22,6 +22,11 @@ public class Music {
   private static HashMap<UUID, SongPlayer> playingSong = new HashMap<>();
 
   public static void start(Player player, Main plugin){
+	if(plugin.getConfig().getBoolean("options.allowDisabling")) {
+		if(plugin.getUserConfigs().getBoolean(player.getUniqueId().toString(),false)) {
+			return;
+		}
+	}
     play(player, plugin);
   }
   public static void stop(Player player) {
@@ -32,7 +37,7 @@ public class Music {
   }
 
   private static void play(Player player, Main plugin) {
-    if (player.hasPermission("JoinMusic.use") || player.isOp()) {
+    if ((player.hasPermission("JoinMusic.use") || player.isOp())) {
       if (!playingSong.containsKey(player.getUniqueId())) {
         playSong(player, plugin);
       } else {

--- a/src/main/java/de/t0biii/music/domain/Music.java
+++ b/src/main/java/de/t0biii/music/domain/Music.java
@@ -37,7 +37,7 @@ public class Music {
   }
 
   private static void play(Player player, Main plugin) {
-    if ((player.hasPermission("JoinMusic.use") || player.isOp())) {
+    if (player.hasPermission("JoinMusic.use") || player.isOp()) {
       if (!playingSong.containsKey(player.getUniqueId())) {
         playSong(player, plugin);
       } else {

--- a/src/main/java/de/t0biii/music/domain/Music.java
+++ b/src/main/java/de/t0biii/music/domain/Music.java
@@ -87,7 +87,7 @@ public class Music {
       String playingMessage = plugin.getConfig().getString("messages.playing");
       if (!playingMessage.isEmpty()) {
         player.sendMessage(plugin.prefix + 
-        		playingMessage.replaceAll("%song%",sp.getSong().getTitle()).replaceAll("&", "§"));
+        		playingMessage.replaceAll("%song%",sp.getSong().getTitle().isEmpty() ? "Untitled" : sp.getSong().getTitle()).replaceAll("&", "§"));
       }
     } catch (IllegalArgumentException e) {
       System.err.println(plugin.cprefix + "No sounds detected");

--- a/src/main/java/de/t0biii/music/domain/Music.java
+++ b/src/main/java/de/t0biii/music/domain/Music.java
@@ -81,9 +81,8 @@ public class Music {
 
       String playingMessage = plugin.getConfig().getString("messages.playing");
       if (!playingMessage.isEmpty()) {
-        player.sendMessage(plugin.prefix + plugin.getConfig().getString("messages.playing")
-        		  			.replaceAll("%song%",sp.getSong().getTitle())
-        		  			.replaceAll("&", "§"));
+        player.sendMessage(plugin.prefix + 
+        		playingMessage.replaceAll("%song%",sp.getSong().getTitle()).replaceAll("&", "§"));
       }
     } catch (IllegalArgumentException e) {
       System.err.println(plugin.cprefix + "No sounds detected");

--- a/src/main/java/de/t0biii/music/domain/Music.java
+++ b/src/main/java/de/t0biii/music/domain/Music.java
@@ -79,12 +79,11 @@ public class Music {
       }
       playingSong.put(player.getUniqueId(), sp);
 
-      if (plugin.getConfig().getBoolean("options.printSongTitel")) {
-        if (!sp.getSong().getTitle().isEmpty()) {
-          player.sendMessage(plugin.prefix + "§2Start Playing the Song:§a§l " + sp.getSong().getTitle());
-        } else {
-          player.sendMessage(plugin.prefix + "§2Start Playing a Song.");
-        }
+      String playingMessage = plugin.getConfig().getString("messages.playing");
+      if (!playingMessage.isEmpty()) {
+        player.sendMessage(plugin.prefix + plugin.getConfig().getString("messages.playing")
+        		  			.replaceAll("%song%",sp.getSong().getTitle())
+        		  			.replaceAll("&", "§"));
       }
     } catch (IllegalArgumentException e) {
       System.err.println(plugin.cprefix + "No sounds detected");

--- a/src/main/java/de/t0biii/music/domain/bStatsCostum.java
+++ b/src/main/java/de/t0biii/music/domain/bStatsCostum.java
@@ -38,16 +38,6 @@ public class bStatsCostum {
             }
         }));
 
-        bstats.addCustomChart(new Metrics.SimplePie("options_printSongTitel", new Callable<String>() {
-            @Override
-            public String call() throws Exception {
-                if (printSongTitel.equalsIgnoreCase("true") || printSongTitel.equalsIgnoreCase("false")) {
-                    return printSongTitel;
-                }
-                return "unknow";
-            }
-        }));
-
         bstats.addCustomChart(new Metrics.SimplePie("options_delaySong", new Callable<String>() {
             @Override
             public String call() throws Exception {

--- a/src/main/java/de/t0biii/music/main/Main.java
+++ b/src/main/java/de/t0biii/music/main/Main.java
@@ -53,8 +53,6 @@ public class Main extends JavaPlugin {
       return;
     }
 
-    cm.loadConfig();
-    saveConfig();
     Updater();
     Music.createRandomFileDir(this);
 
@@ -91,6 +89,13 @@ public class Main extends JavaPlugin {
     }
   }
   
+  public void reloadConfigs() {
+	  this.reloadConfig();
+	  cm.loadConfig();
+	  this.saveConfig();
+	  this.loadUserConfigsIfNeeded();
+  }
+  
   public void loadUserConfigsIfNeeded() {
 	if (this.getConfig().getBoolean("options.allowDisabling")) {
 	  createUserConfigs();
@@ -114,6 +119,7 @@ public class Main extends JavaPlugin {
   public FileConfiguration getUserConfigs() {
     return this.userConfigs;
   }
+  
   public void saveUserConfigs() {
 	try {
 	  this.userConfigs.save(new File(getDataFolder(), "disabledPlayers.yml"));

--- a/src/main/java/de/t0biii/music/main/Main.java
+++ b/src/main/java/de/t0biii/music/main/Main.java
@@ -1,7 +1,5 @@
 package de.t0biii.music.main;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.logging.Logger;
 import de.t0biii.music.commands.CMD_PlayMusic;
 import de.t0biii.music.domain.ConfigManager;
@@ -13,9 +11,6 @@ import de.t0biii.music.listener.HANDLER_PlayerQuit;
 import de.t0biii.music.listener.HANDLER_SongEndEvent;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
-import org.bukkit.configuration.InvalidConfigurationException;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import de.t0biii.music.domain.bStatsCostum;
@@ -33,7 +28,6 @@ public class Main extends JavaPlugin {
   private int uid = 83541;
   public Updater updater;
   
-  private FileConfiguration userConfigs = null;
 
 
   public ConfigManager cm = new ConfigManager(this);
@@ -55,7 +49,7 @@ public class Main extends JavaPlugin {
     
     cm.loadConfig();
     saveConfig();
-    loadUserConfigsIfNeeded();
+    cm.loadUserConfigsIfNeeded();
     
     Updater();
     Music.createRandomFileDir(this);
@@ -92,42 +86,4 @@ public class Main extends JavaPlugin {
     }
   }
   
-  public void reloadConfigs() {
-	  this.reloadConfig();
-	  cm.loadConfig();
-	  this.saveConfig();
-	  this.loadUserConfigsIfNeeded();
-  }
-  
-  public void loadUserConfigsIfNeeded() {
-	if (this.getConfig().getBoolean("options.allowDisabling")) {
-	  createUserConfigs();
-	}
-  }
-  
-  private void createUserConfigs() {
-	File userConfigsFile = new File(getDataFolder(), "disabledPlayers.yml");
-    if (!userConfigsFile.exists()) {
-      userConfigsFile.getParentFile().mkdirs();
-      saveResource("disabledPlayers.yml", false);
-    }
-	userConfigs = new YamlConfiguration();
-	try {
-        userConfigs.load(userConfigsFile);
-    } catch (IOException | InvalidConfigurationException e) {
-        e.printStackTrace();
-    }
-  }
-  
-  public FileConfiguration getUserConfigs() {
-    return this.userConfigs;
-  }
-  
-  public void saveUserConfigs() {
-	try {
-	  this.userConfigs.save(new File(getDataFolder(), "disabledPlayers.yml"));
-	} catch (IOException e) {
-		e.printStackTrace();
-	}
-  }
 }

--- a/src/main/java/de/t0biii/music/main/Main.java
+++ b/src/main/java/de/t0biii/music/main/Main.java
@@ -52,7 +52,11 @@ public class Main extends JavaPlugin {
       log.info(cprefix + "Disabled!");
       return;
     }
-
+    
+    cm.loadConfig();
+    saveConfig();
+    loadUserConfigsIfNeeded();
+    
     Updater();
     Music.createRandomFileDir(this);
 
@@ -61,7 +65,6 @@ public class Main extends JavaPlugin {
       new bStatsCostum(this).customCharts(metrics);
     }
     
-    loadUserConfigsIfNeeded();
 
     pm.registerEvents(new HANDLER_PlayerJoin(this), this);
     pm.registerEvents(new HANDLER_PlayerQuit(), this);

--- a/src/main/java/de/t0biii/music/main/Main.java
+++ b/src/main/java/de/t0biii/music/main/Main.java
@@ -12,7 +12,7 @@ import de.t0biii.music.listener.HANDLER_SongEndEvent;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
-import org.bukkit.plugin.java.JavaPlugin;;
+import org.bukkit.plugin.java.JavaPlugin;
 import de.t0biii.music.domain.bStatsCostum;
 
 

--- a/src/main/java/de/t0biii/music/main/Main.java
+++ b/src/main/java/de/t0biii/music/main/Main.java
@@ -1,5 +1,7 @@
 package de.t0biii.music.main;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.logging.Logger;
 import de.t0biii.music.commands.CMD_PlayMusic;
 import de.t0biii.music.domain.ConfigManager;
@@ -11,6 +13,9 @@ import de.t0biii.music.listener.HANDLER_PlayerQuit;
 import de.t0biii.music.listener.HANDLER_SongEndEvent;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import de.t0biii.music.domain.bStatsCostum;
@@ -27,6 +32,8 @@ public class Main extends JavaPlugin {
   public String link2 = "http://dev.bukkit.org/bukkit-plugins/joinmusic/";
   private int uid = 83541;
   public Updater updater;
+  
+  private FileConfiguration userConfigs = null;
 
 
   public ConfigManager cm = new ConfigManager(this);
@@ -55,6 +62,8 @@ public class Main extends JavaPlugin {
       Metrics metrics = new Metrics(this, 6447);
       new bStatsCostum(this).customCharts(metrics);
     }
+    
+    loadUserConfigsIfNeeded();
 
     pm.registerEvents(new HANDLER_PlayerJoin(this), this);
     pm.registerEvents(new HANDLER_PlayerQuit(), this);
@@ -80,5 +89,36 @@ public class Main extends JavaPlugin {
         log.info(cprefix + "Download at: " + link2);
       }
     }
+  }
+  
+  public void loadUserConfigsIfNeeded() {
+	if (this.getConfig().getBoolean("options.allowDisabling")) {
+	  createUserConfigs();
+	}
+  }
+  
+  private void createUserConfigs() {
+	File userConfigsFile = new File(getDataFolder(), "disabledPlayers.yml");
+    if (!userConfigsFile.exists()) {
+      userConfigsFile.getParentFile().mkdirs();
+      saveResource("disabledPlayers.yml", false);
+    }
+	userConfigs = new YamlConfiguration();
+	try {
+        userConfigs.load(userConfigsFile);
+    } catch (IOException | InvalidConfigurationException e) {
+        e.printStackTrace();
+    }
+  }
+  
+  public FileConfiguration getUserConfigs() {
+    return this.userConfigs;
+  }
+  public void saveUserConfigs() {
+	try {
+	  this.userConfigs.save(new File(getDataFolder(), "disabledPlayers.yml"));
+	} catch (IOException e) {
+		e.printStackTrace();
+	}
   }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,20 +16,20 @@ commands:
       - jm
       - joinmusic
       - joinmusik
-    permissions:
-      JoinMusic.command.reload:
-        description: Allows reloading configs
-        default: op
-      JoinMusic.update:
-        description: Will get info about updates
-        default: op
-      JoinMusic.command.stop:
-        description: Allows stopping music from playing
-        default: true
-      JoinMusic.command.disableOwn:
-        description: Allows disabling music on join for themself
-        default: true
-      JoinMusic.use:
-        description: Allows the user to hear the music on join
-        default: true
+permissions:
+  JoinMusic.command.reload:
+    description: Allows reloading configs
+    default: op
+  JoinMusic.update:
+    description: Will get info about updates
+    default: op
+  JoinMusic.command.stop:
+    description: Allows stopping music from playing
+    default: true
+  JoinMusic.command.disableOwn:
+    description: Allows disabling music on join for themself
+    default: true
+  JoinMusic.use:
+    description: Allows the user to hear the music on join and access the command
+    default: true
 api-version: 1.13

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,7 +11,7 @@ database: false
 commands:
   JoinMusic:
     description: /JoinMusic
-    usage: /<command> [reload]
+    usage: /<command> [reload | stop | enable | disable]
     aliases:
       - jm
       - joinmusic

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -17,7 +17,16 @@ commands:
       - joinmusic
       - joinmusik
     permissions:
-      JoinMusik.command.reload
-      JoinMusik.command.stop
-      JoinMusik.use
+      JoinMusic.command.reload:
+        description: Allows reloading configs
+        default: op
+      JoinMusic.update:
+        description: Will get info about updates
+        default: op
+      JoinMusic.command.stop:
+        description: Allows stopping music from playing
+        default: true
+      JoinMusic.use:
+        description: Allows the user to hear the music on join
+        default: true
 api-version: 1.13

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,6 +26,9 @@ commands:
       JoinMusic.command.stop:
         description: Allows stopping music from playing
         default: true
+      JoinMusic.command.disableOwn:
+        description: Allows disabling music on join for themself
+        default: true
       JoinMusic.use:
         description: Allows the user to hear the music on join
         default: true


### PR DESCRIPTION
This PR adds multiple things:

- The major feature, it adds the ability for players to disable the music on join
  - It can be disabled in the config, if enabled creates a file with user configs for those who disable the music.
  - It has its own permission `JoinMusic.command.disableOwn` both to enable and disable.
  - The feature adds 2 subcommands, `/jm enable` and `/jm disable`, which are available in the help menu. To remove them from the help menu (usually if the feature is disabled) the permission has to be removed from the user (can't access Main from a static method to just check if the feature is enabled in config)
  - The state will not be saved unless the player explicitly wants to disable it, saving file size
  - It edits the `/jm stop` to suggest the new `/jm disable` command, and the `/jm disable` suggests the `/jm enable` command
- It removes the `/jm reload` from help menu for users without the reload permission
- It makes all messages that are shown to regular players translatable (basically help menu and started playing)
  - It makes those messages (except help menu) colorable too with the `&` codes (formattable too).
  - To show the song title, it replaces a placeholder, `%song%` (only in the started playing message)
  - This last change effectively removes `printSongTitel`, since now you can just remove the placeholder, and also removes the bStats stat for it
- It updates permissions and commands in `plugin.yml`
  - It adds the new subcommands (`stop` | `enable` | `disable`) to the `/help` usage of the command
  - It updates the permissions to the new names and sets the ones that are normal for regular users by default (they should still be able to be removed from other permissions plugins)
- It allows reloading the plugin from the console
  - The rest of commands show a slightly different message when running from the console (`Only reload is for console!`).
  - It also makes the commands from console use `cprefix` instead of regular `prefix`
- It also fixes a few things:
  - When reloading, if some configuration values have been removed (or the entire file), they won't be repopulated with defaults, since nothing is setting them, and would return `null` for them. Next time it would fail to reload (at least with my added feature)
  - Nano fix: Removed a double semicolon in an import in Main, preventing from compiling

Why I do this: Even though I stopped using Spigot years ago for various reasons, today while looking at NBS again I remembered this plugin, that I really liked when I used it, and since I saw it was in GitHub (and I was so bored) I decided to help by adding a few things to it, mostly the small things I remembered users asked for or I thought may be useful.

I've only tested this in the last "stable" Spigot version (aka 1.15.2) from BuildTools but it _should_ work in others (I suppose).

If you have any doubt about anything just reply here and I will reply too. Maybe I'm missing something in this list.
Also the version should be bumped if you think it's correct. And feel free to change the new messages format, I'm not really good at designing.