### PR TITLE
feat(commands): add toggle command for joinmusic

### DIFF
--- a/Paper/src/main/java/de/t0biii/joinmusic/spigot/commands/CMD_PlayMusic.java
+++ b/Paper/src/main/java/de/t0biii/joinmusic/spigot/commands/CMD_PlayMusic.java
@@ -54,7 +54,7 @@ public class CMD_PlayMusic implements CommandExecutor {
         	  }else {
         		sender.sendMessage(plugin.prefix + noperm);
         	  }
-          }else if (args[0].equalsIgnoreCase("enable") && plugin.getConfig().getBoolean("options.allowDisabling")) {
+          } else if (args[0].equalsIgnoreCase("enable") && plugin.getConfig().getBoolean("options.allowDisabling")) {
         	  if(sender.hasPermission("JoinMusic.command.disableOwn")) {
         		  plugin.cm.getUserConfigs().set(player.getUniqueId().toString(),null);
         		  plugin.cm.saveUserConfigs();
@@ -62,6 +62,21 @@ public class CMD_PlayMusic implements CommandExecutor {
         	  } else {
         		sender.sendMessage(plugin.prefix + noperm);
         	  }
+          } else if (args[0].equalsIgnoreCase("toggle") && plugin.getConfig().getBoolean("options.allowDisabling")) {
+              if(sender.hasPermission("JoinMusic.command.disableOwn")) {
+                boolean isDisabled = plugin.cm.getUserConfigs().getBoolean(player.getUniqueId().toString());
+                  if(isDisabled) {
+                      plugin.cm.getUserConfigs().set(player.getUniqueId().toString(), null);
+                      plugin.cm.saveUserConfigs();
+                      sender.sendMessage(plugin.prefix + plugin.getConfig().getString("messages.enabled").replaceAll("&", "§"));
+                  } else {
+                      plugin.cm.getUserConfigs().set(player.getUniqueId().toString(), true);
+                      plugin.cm.saveUserConfigs();
+                      sender.sendMessage(plugin.prefix + plugin.getConfig().getString("messages.disabled").replaceAll("&", "§"));
+                  }
+              } else {
+                  sender.sendMessage(plugin.prefix + noperm);
+              }
           } else{
             sendInstructions(player);
           }
@@ -98,6 +113,8 @@ public class CMD_PlayMusic implements CommandExecutor {
           + ChatColor.GREEN + plugin.getConfig().getString("messages.help.disableOwn"));
       sender.sendMessage(ChatColor.GRAY + "/jm " + ChatColor.GREEN + "enable   " + ChatColor.DARK_GRAY + "| "
           + ChatColor.GREEN + plugin.getConfig().getString("messages.help.enableOwn"));
+      sender.sendMessage(ChatColor.GRAY + "/jm " + ChatColor.GREEN + "toggle   " + ChatColor.DARK_GRAY + "| "
+          + ChatColor.GREEN + "Toggle JoinMusic on/off");
       sender.sendMessage(ChatColor.GRAY + "======= " + ChatColor.GREEN + plugin.prefix + ChatColor.GRAY + "=======");
     }
   }
@@ -116,6 +133,7 @@ public class CMD_PlayMusic implements CommandExecutor {
         if (commandSender.hasPermission("JoinMusic.command.disableOwn")) {
           list.add("enable");
           list.add("disable");
+          list.add("toggle");
         }
         if (!commandSender.hasPermission("JoinMusic.command.stop")
             && !commandSender.hasPermission("JoinMusic.command.reload")

--- a/README.md
+++ b/README.md
@@ -87,13 +87,14 @@ messages:
 - `/joinmusic stop` - Stops the currently playing music
 - `/joinmusic disable` - Disables automatic music playback when joining the server
 - `/joinmusic enable` - Enables automatic music playback when joining the server
+- `/joinmusic toggle` - Toggles (enables or disables) automatic music playback when joining the server
 
 ## Permissions
 - `JoinMusic.use` - Allows using the /joinmusic command
 - `JoinMusic.play` - Allows using /joinmusic play
 - `JoinMusic.command.stop` - Allows using /joinmusic stop
 - `JoinMusic.command.reload` - Allows using /joinmusic reload
-- `JoinMusic.command.disableOwn` - Allows using /joinmusic disable and /jm enable
+- `JoinMusic.command.disableOwn` - Allows using /joinmusic disable/enable/toggle
 - `JoinMusic.update` - Receives update notifications
 
 ## PlaceholderAPI

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -82,6 +82,26 @@ Enables automatic music playback when joining the server. This setting is saved 
 > /jm enable
 [JoinMusic] Enabled playing a song when joining
 ```
+### Toggle Command
+```
+/joinmusic toggle
+/jm toggle
+```
+Toggles (enables or disables) automatic music playback when joining the server. This setting is saved per player.
+
+**Permission:** `JoinMusic.command.disableOwn`
+
+**Example:**
+```
+> /jm toggle
+[JoinMusic] Disabled playing a song when joining. To enable it again, use /jm enable
+```
+
+```
+> /jm toggle
+[JoinMusic] Enabled playing a song when joining
+```
+
 
 ## Command Messages
 


### PR DESCRIPTION
Implement a new toggle command that allows users to switch between enabled and disabled states for automatic music playback. This provides a more convenient way to manage playback preferences compared to separate enable/disable commands.

closes #159